### PR TITLE
Add per-page template selection via template_file

### DIFF
--- a/sample-genereto-project/content/about.md
+++ b/sample-genereto-project/content/about.md
@@ -1,0 +1,33 @@
+---
+title: About Us
+description: Learn more about this sample Genereto website
+keywords: about, genereto, static site
+template_file: landing.html
+---
+
+## Our Story
+
+This page demonstrates the **per-page template selection** feature in Genereto. Notice how this page uses a different layout than the home page - it has a hero section with a gradient background!
+
+## How It Works
+
+To use a custom template for any page, simply add `template_file` to your frontmatter:
+
+```yaml
+---
+title: About Us
+description: Learn more about us
+template_file: landing.html
+---
+```
+
+The `template_file` path is relative to your template directory. You can also use nested paths like `layouts/gallery.html`.
+
+## Features
+
+- Different visual style from the default template
+- Hero section with gradient background
+- Same header and footer (via includes)
+- Full SEO metadata support
+
+[Back to Home](index.html) | [Visit the Blog](blog/index.html)

--- a/sample-genereto-project/templates/main/landing.html
+++ b/sample-genereto-project/templates/main/landing.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>$GENERETO['title']</title>
+    <link rel="stylesheet" href="res/styles.css">
+    <meta name="description" content="$GENERETO['description']">
+    <meta name="keywords" content="$GENERETO['keywords']">
+    <meta property="og:title" content="$GENERETO['title']">
+    <meta property="og:description" content="$GENERETO['description']">
+    <meta property="og:url" content="$GENERETO['url']">
+    <meta property="og:image" content="$GENERETO['cover_image']">
+    <style>
+        /* Landing page specific styles */
+        .landing-hero {
+            text-align: center;
+            padding: 4rem 2rem;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            margin-bottom: 2rem;
+        }
+        .landing-hero h1 {
+            font-size: 3rem;
+            margin-bottom: 1rem;
+        }
+        .landing-content {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+    </style>
+</head>
+<body>
+
+$GENERETO_INCLUDE['header.html']
+
+<div class="landing-hero">
+    <h1>$GENERETO['title']</h1>
+    <p>$GENERETO['description']</p>
+</div>
+
+<main class="landing-content">
+    <article>
+        <!-- start_content -->
+        Sample content (replaced during build)
+        <!-- end_content -->
+    </article>
+</main>
+
+$GENERETO_INCLUDE['footer.html']
+
+</body>
+</html>

--- a/src/page_metadata.rs
+++ b/src/page_metadata.rs
@@ -34,6 +34,8 @@ pub struct PageMetadataRaw {
     pub cover_image: Option<String>,
     /// Optional URL for external links
     pub url: Option<String>,
+    /// Optional template file override for this specific page
+    pub template_file: Option<String>,
     /// Custom metadata fields that will be available as $GENERETO['field_name']
     #[serde(flatten)]
     pub custom_metadata: HashMap<String, String>,
@@ -68,6 +70,8 @@ pub struct PageMetadata {
     pub article_url: Option<String>,
     /// Base website url. https://www.example.com
     pub website_url: String,
+    /// Optional template file override for this specific page
+    pub template_file: Option<String>,
     /// Custom metadata fields that will be available as $GENERETO['field_name']
     pub custom_metadata: HashMap<String, String>,
 }
@@ -130,6 +134,7 @@ impl PageMetadata {
             table_of_contents,
             article_url: page_metadata.url,
             website_url: website_url.to_string(),
+            template_file: page_metadata.template_file,
             custom_metadata: page_metadata.custom_metadata,
         }
     }
@@ -537,6 +542,7 @@ mod test {
             description: None,
             cover_image: None,
             url: None,
+            template_file: None,
             custom_metadata: HashMap::new(),
         };
 
@@ -603,6 +609,7 @@ mod test {
             add_title: false,
             article_url: None,
             website_url: "https://fponzi.me".to_string(),
+            template_file: None,
             custom_metadata,
         };
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -25,6 +25,15 @@ pub fn process_includes(template_raw: &str, template_dir: &Path) -> anyhow::Resu
     Ok(result)
 }
 
+/// Load a template file from the template directory and process includes
+/// Returns the processed template content
+pub fn load_template(template_dir: &Path, template_filename: &str) -> anyhow::Result<String> {
+    let template_path = template_dir.join(template_filename);
+    let template_raw = fs::read_to_string(&template_path)
+        .with_context(|| format!("Failed to read template file '{}'", template_path.display()))?;
+    process_includes(&template_raw, template_dir)
+}
+
 pub(crate) const START_PATTERN: &str = "<!-- start_content -->";
 pub(crate) const END_PATTERN: &str = "<!-- end_content -->";
 
@@ -163,8 +172,9 @@ pub fn compile_page_phase_2(
     Ok((final_page, metadata))
 }
 
-// Split the source content into the metadata and the content
-fn compile_page_phase_1(source_content: &str) -> anyhow::Result<(String, PageMetadataRaw)> {
+/// Split the source content into the metadata and the content
+/// This function is public so that callers can parse metadata first to check for template_file
+pub fn compile_page_phase_1(source_content: &str) -> anyhow::Result<(String, PageMetadataRaw)> {
     let trimmed_content = source_content.trim_start();
 
     if trimmed_content.starts_with("---") {

--- a/tests/test_per_page_template.rs
+++ b/tests/test_per_page_template.rs
@@ -1,0 +1,463 @@
+use std::fs;
+use tempfile::tempdir;
+
+/// Test that pages can specify a custom template via `template_file` frontmatter
+#[test]
+fn test_page_with_custom_template() {
+    let temp_dir = tempdir().unwrap();
+    let project_path = temp_dir.path();
+
+    // Create project structure
+    fs::create_dir_all(project_path.join("content")).unwrap();
+    fs::create_dir_all(project_path.join("templates/main")).unwrap();
+
+    // Create config
+    fs::write(
+        project_path.join("config.yml"),
+        r#"
+template: main
+title: Custom Template Test
+url: https://test.example.com
+description: Testing per-page templates
+"#,
+    )
+    .unwrap();
+
+    // Create default template (index.html)
+    fs::write(
+        project_path.join("templates/main/index.html"),
+        r#"<!DOCTYPE html>
+<html>
+<head><title>DEFAULT TEMPLATE: $GENERETO['title']</title></head>
+<body>
+<!-- start_content --><!-- end_content -->
+</body>
+</html>"#,
+    )
+    .unwrap();
+
+    // Create custom landing template
+    fs::write(
+        project_path.join("templates/main/landing.html"),
+        r#"<!DOCTYPE html>
+<html>
+<head><title>LANDING TEMPLATE: $GENERETO['title']</title></head>
+<body class="landing-page">
+<!-- start_content --><!-- end_content -->
+</body>
+</html>"#,
+    )
+    .unwrap();
+
+    // Create a page using default template
+    fs::write(
+        project_path.join("content/normal-page.md"),
+        r#"---
+title: Normal Page
+publish_date: 2024-01-01
+description: A page using default template
+---
+
+# Normal Page Content
+
+This page uses the default template.
+"#,
+    )
+    .unwrap();
+
+    // Create a page using custom template
+    fs::write(
+        project_path.join("content/landing-page.md"),
+        r#"---
+title: Landing Page
+publish_date: 2024-01-02
+description: A page using custom landing template
+template_file: landing.html
+---
+
+# Landing Page Content
+
+This page uses the landing template.
+"#,
+    )
+    .unwrap();
+
+    // Run genereto
+    let result = genereto::run(project_path.to_path_buf(), genereto::DraftsOptions::Build);
+    assert!(result.is_ok(), "Failed to generate site: {:?}", result);
+
+    // Check normal page uses default template
+    let normal_page = fs::read_to_string(project_path.join("output/normal-page.html"))
+        .expect("Normal page should exist");
+    assert!(
+        normal_page.contains("DEFAULT TEMPLATE: Normal Page"),
+        "Normal page should use default template: {}",
+        normal_page
+    );
+
+    // Check landing page uses custom template
+    let landing_page = fs::read_to_string(project_path.join("output/landing-page.html"))
+        .expect("Landing page should exist");
+    assert!(
+        landing_page.contains("LANDING TEMPLATE: Landing Page"),
+        "Landing page should use landing template: {}",
+        landing_page
+    );
+    assert!(
+        landing_page.contains("class=\"landing-page\""),
+        "Landing page should have landing-page class: {}",
+        landing_page
+    );
+}
+
+/// Test that blog posts can also use custom templates
+#[test]
+fn test_blog_post_with_custom_template() {
+    let temp_dir = tempdir().unwrap();
+    let project_path = temp_dir.path();
+
+    // Create project structure
+    fs::create_dir_all(project_path.join("content/blog")).unwrap();
+    fs::create_dir_all(project_path.join("templates/main")).unwrap();
+
+    // Create config
+    fs::write(
+        project_path.join("config.yml"),
+        r#"
+template: main
+title: Blog Template Test
+url: https://test.example.com
+description: Testing per-page templates in blog
+blog:
+  base_template: blog-index.html
+  index_name: index.html
+  destination: blog
+  generate_single_pages: true
+"#,
+    )
+    .unwrap();
+
+    // Create default page template (required for compile_pages)
+    fs::write(
+        project_path.join("templates/main/index.html"),
+        r#"<!DOCTYPE html>
+<html>
+<head><title>$GENERETO['title']</title></head>
+<body><!-- start_content --><!-- end_content --></body>
+</html>"#,
+    )
+    .unwrap();
+
+    // Create default blog template
+    fs::write(
+        project_path.join("templates/main/blog.html"),
+        r#"<!DOCTYPE html>
+<html>
+<head><title>BLOG TEMPLATE: $GENERETO['title']</title></head>
+<body>
+<!-- start_content --><!-- end_content -->
+</body>
+</html>"#,
+    )
+    .unwrap();
+
+    // Create blog index template
+    fs::write(
+        project_path.join("templates/main/blog-index.html"),
+        r#"<!DOCTYPE html>
+<html>
+<body>
+<!-- start_content -->
+<div class="post"><a href="$GENERETO['file_name']">$GENERETO['title']</a></div>
+<!-- end_content -->
+</body>
+</html>"#,
+    )
+    .unwrap();
+
+    // Create custom featured template
+    fs::write(
+        project_path.join("templates/main/featured.html"),
+        r#"<!DOCTYPE html>
+<html>
+<head><title>FEATURED TEMPLATE: $GENERETO['title']</title></head>
+<body class="featured-post">
+<!-- start_content --><!-- end_content -->
+</body>
+</html>"#,
+    )
+    .unwrap();
+
+    // Create a normal blog post
+    fs::write(
+        project_path.join("content/blog/normal-post.md"),
+        r#"---
+title: Normal Post
+publish_date: 2024-01-01
+description: A normal blog post
+---
+
+# Normal Post Content
+"#,
+    )
+    .unwrap();
+
+    // Create a featured blog post with custom template
+    fs::write(
+        project_path.join("content/blog/featured-post.md"),
+        r#"---
+title: Featured Post
+publish_date: 2024-01-02
+description: A featured blog post
+template_file: featured.html
+---
+
+# Featured Post Content
+"#,
+    )
+    .unwrap();
+
+    // Run genereto
+    let result = genereto::run(project_path.to_path_buf(), genereto::DraftsOptions::Build);
+    assert!(result.is_ok(), "Failed to generate site: {:?}", result);
+
+    // Check normal post uses default blog template
+    let normal_post = fs::read_to_string(project_path.join("output/blog/normal-post.html"))
+        .expect("Normal post should exist");
+    assert!(
+        normal_post.contains("BLOG TEMPLATE: Normal Post"),
+        "Normal post should use blog template: {}",
+        normal_post
+    );
+
+    // Check featured post uses custom template
+    let featured_post = fs::read_to_string(project_path.join("output/blog/featured-post.html"))
+        .expect("Featured post should exist");
+    assert!(
+        featured_post.contains("FEATURED TEMPLATE: Featured Post"),
+        "Featured post should use featured template: {}",
+        featured_post
+    );
+    assert!(
+        featured_post.contains("class=\"featured-post\""),
+        "Featured post should have featured-post class: {}",
+        featured_post
+    );
+}
+
+/// Test that missing template produces a clear error
+#[test]
+fn test_missing_template_error() {
+    let temp_dir = tempdir().unwrap();
+    let project_path = temp_dir.path();
+
+    // Create project structure
+    fs::create_dir_all(project_path.join("content")).unwrap();
+    fs::create_dir_all(project_path.join("templates/main")).unwrap();
+
+    // Create config
+    fs::write(
+        project_path.join("config.yml"),
+        r#"
+template: main
+title: Missing Template Test
+url: https://test.example.com
+description: Testing missing template error
+"#,
+    )
+    .unwrap();
+
+    // Create default template only
+    fs::write(
+        project_path.join("templates/main/index.html"),
+        r#"<!DOCTYPE html>
+<html>
+<head><title>$GENERETO['title']</title></head>
+<body><!-- start_content --><!-- end_content --></body>
+</html>"#,
+    )
+    .unwrap();
+
+    // Create a page referencing a non-existent template
+    fs::write(
+        project_path.join("content/broken-page.md"),
+        r#"---
+title: Broken Page
+publish_date: 2024-01-01
+description: A page with missing template
+template_file: nonexistent.html
+---
+
+# Content
+"#,
+    )
+    .unwrap();
+
+    // Run genereto - should fail
+    let result = genereto::run(project_path.to_path_buf(), genereto::DraftsOptions::Build);
+    assert!(result.is_err(), "Should fail when template is missing");
+
+    let error_message = result.unwrap_err().to_string();
+    assert!(
+        error_message.contains("nonexistent.html") || error_message.contains("template"),
+        "Error should mention the missing template: {}",
+        error_message
+    );
+}
+
+/// Test per-page templates with Jinja2 mode enabled
+#[test]
+fn test_per_page_template_with_jinja() {
+    let temp_dir = tempdir().unwrap();
+    let project_path = temp_dir.path();
+
+    // Create project structure
+    fs::create_dir_all(project_path.join("content")).unwrap();
+    fs::create_dir_all(project_path.join("templates/main")).unwrap();
+
+    // Create config with jinja enabled
+    fs::write(
+        project_path.join("config.yml"),
+        r#"
+template: main
+enable_jinja: true
+title: Jinja Template Test
+url: https://test.example.com
+description: Testing per-page templates with Jinja
+"#,
+    )
+    .unwrap();
+
+    // Create default template with Jinja syntax
+    fs::write(
+        project_path.join("templates/main/index.html"),
+        r#"<!DOCTYPE html>
+<html>
+<head><title>DEFAULT: {{ page.title }}</title></head>
+<body>{{ content }}</body>
+</html>"#,
+    )
+    .unwrap();
+
+    // Create custom template with Jinja syntax
+    fs::write(
+        project_path.join("templates/main/special.html"),
+        r#"<!DOCTYPE html>
+<html>
+<head><title>SPECIAL: {{ page.title }}</title></head>
+<body class="special">{{ content }}</body>
+</html>"#,
+    )
+    .unwrap();
+
+    // Create a page using custom template
+    fs::write(
+        project_path.join("content/special-page.md"),
+        r#"---
+title: Special Page
+publish_date: 2024-01-01
+description: A special page
+template_file: special.html
+---
+
+# Special Content
+"#,
+    )
+    .unwrap();
+
+    // Run genereto
+    let result = genereto::run(project_path.to_path_buf(), genereto::DraftsOptions::Build);
+    assert!(result.is_ok(), "Failed to generate site: {:?}", result);
+
+    // Check special page uses custom template with Jinja rendering
+    let special_page = fs::read_to_string(project_path.join("output/special-page.html"))
+        .expect("Special page should exist");
+    assert!(
+        special_page.contains("<title>SPECIAL: Special Page</title>"),
+        "Special page should use Jinja special template: {}",
+        special_page
+    );
+    assert!(
+        special_page.contains("class=\"special\""),
+        "Special page should have special class: {}",
+        special_page
+    );
+}
+
+/// Test template path resolution for nested templates
+#[test]
+fn test_nested_template_path() {
+    let temp_dir = tempdir().unwrap();
+    let project_path = temp_dir.path();
+
+    // Create project structure with nested templates
+    fs::create_dir_all(project_path.join("content")).unwrap();
+    fs::create_dir_all(project_path.join("templates/main/layouts")).unwrap();
+
+    // Create config
+    fs::write(
+        project_path.join("config.yml"),
+        r#"
+template: main
+title: Nested Template Test
+url: https://test.example.com
+description: Testing nested template paths
+"#,
+    )
+    .unwrap();
+
+    // Create default template
+    fs::write(
+        project_path.join("templates/main/index.html"),
+        r#"<!DOCTYPE html>
+<html>
+<head><title>DEFAULT: $GENERETO['title']</title></head>
+<body><!-- start_content --><!-- end_content --></body>
+</html>"#,
+    )
+    .unwrap();
+
+    // Create nested template
+    fs::write(
+        project_path.join("templates/main/layouts/gallery.html"),
+        r#"<!DOCTYPE html>
+<html>
+<head><title>GALLERY: $GENERETO['title']</title></head>
+<body class="gallery"><!-- start_content --><!-- end_content --></body>
+</html>"#,
+    )
+    .unwrap();
+
+    // Create a page using nested template path
+    fs::write(
+        project_path.join("content/my-gallery.md"),
+        r#"---
+title: My Gallery
+publish_date: 2024-01-01
+description: A gallery page
+template_file: layouts/gallery.html
+---
+
+# Gallery Content
+"#,
+    )
+    .unwrap();
+
+    // Run genereto
+    let result = genereto::run(project_path.to_path_buf(), genereto::DraftsOptions::Build);
+    assert!(result.is_ok(), "Failed to generate site: {:?}", result);
+
+    // Check gallery page uses nested template
+    let gallery_page = fs::read_to_string(project_path.join("output/my-gallery.html"))
+        .expect("Gallery page should exist");
+    assert!(
+        gallery_page.contains("GALLERY: My Gallery"),
+        "Gallery page should use nested gallery template: {}",
+        gallery_page
+    );
+    assert!(
+        gallery_page.contains("class=\"gallery\""),
+        "Gallery page should have gallery class: {}",
+        gallery_page
+    );
+}


### PR DESCRIPTION
frontmatter.

Allow pages and blog posts to specify a custom template file via the `template_file` field in YAML frontmatter. This enables different layouts
for different page types (landing pages, galleries, featured posts, etc.).

- Add template_file field to PageMetadataRaw and PageMetadata structs
- Add load_template() helper and make compile_page_phase_1 public
- Refactor compile_pages() and build_articles() to check for custom template
- Add integration tests for per-page template feature
- Update sample project with landing template example
- Update CLAUDE.md documentation

Closes #21